### PR TITLE
Features to finalize progress bar

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -41,6 +41,9 @@ impl ProgressBar {
     ///     // update the progression by 1
     ///     progress_bar.inc();
     /// }
+    /// progress_bar.print_final_info("Loading", "Load complete", Color::LightGreen, Style::Bold);
+    /// // Or, to leave the progress bar at 100%:
+    /// // progress_bar.finalize();
     /// ```
     pub fn new(max: usize) -> Self {
         ProgressBar {
@@ -93,6 +96,13 @@ impl ProgressBar {
         self.display();
     }
 
+    /// Log something, without display update
+    pub fn print_final_info(&mut self, info_name: &str, text: &str, info_color: Color, info_style: Style) {
+        let info_name = ProgressBar::set_good_size(info_name);
+        println!("{}{}{}\x1B[0m {}\x1B[K", info_style, info_color, info_name, text);
+        self.progression = 0;
+    }
+
     /// Log something
     pub fn print_info(&mut self, info_name: &str, text: &str, info_color: Color, info_style: Style) {
         let info_name = ProgressBar::set_good_size(info_name);
@@ -119,5 +129,10 @@ impl ProgressBar {
         print!("] {}/{}", self.progression, self.max);
         print!("\n\x1B[1A")
     }
-
+    
+    /// Mark the end of the progress bar - updates will make a 'new' bar
+    pub fn finalize(&mut self) {
+        self.progression = 0;
+        println!("");
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,5 +19,23 @@ fn test() {
         }
         thread::sleep(time::Duration::from_millis(50));
     }
+    test.finalize();
+
+    println!("Normal print macro");
+
+    let mut test = ProgressBar::new(100);
+    test.set_action("Loading", Color::Blue, Style::Bold);
     
+    for i in 0..100 {
+        test.inc();
+        if i == 14 {
+            test.print_info("Failed", "to load a page", Color::Red, Style::Blink);
+        } else if i == 48 {
+            test.print_info("Found", "something interessant", Color::LightGreen, Style::Normal);
+        } else if i == 75 {
+            test.print_info("Warning", "empty page here", Color::Yellow, Style::Underlined);
+        }
+        thread::sleep(time::Duration::from_millis(50));
+    }
+    test.print_final_info("Loading", "Load complete", Color::LightGreen, Style::Bold);
 }


### PR DESCRIPTION
Using println! after a progress bar generates garbled output. Calling the new print_final_info() will replace progress bar with info text line, or calling finalize() will leave the progress bar at its last value. Both reset the progression to 0.