### PR TITLE
Added `action_mode`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "progress_bar"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Mubelotix <unbeliever.in.time@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,5 +1,5 @@
 use std::sync::Mutex;
-use crate::{style::{Color, Style}, pb::ProgressBar};
+use crate::{style::{Color, Style, Mode}, pb::ProgressBar};
 
 lazy_static::lazy_static! {
     pub static ref CURRENT_PROGRESS_BAR: Mutex<Option<ProgressBar>> = Mutex::new(None);
@@ -46,9 +46,9 @@ pub fn print_progress_bar_info(info_name: &str, text: &str, info_color: Color, i
     }
 }
 
-pub fn set_progress_bar_action(action: &str, color: Color, style: Style) {
+pub fn set_progress_bar_action(action: &str, color: Color, style: Style, mode: Mode) {
     match *CURRENT_PROGRESS_BAR.lock().unwrap() {
-        Some(ref mut progress_bar) => progress_bar.set_action(action, color, style),
+        Some(ref mut progress_bar) => progress_bar.set_action(action, color, style, mode),
         None => eprintln!("ERROR: Unable to set progress bar action (no progress bar)"),
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,5 +1,8 @@
+use crate::{
+    pb::ProgressBar,
+    style::{Color, Mode, Style},
+};
 use std::sync::Mutex;
-use crate::{style::{Color, Style, Mode}, pb::ProgressBar};
 
 lazy_static::lazy_static! {
     pub static ref CURRENT_PROGRESS_BAR: Mutex<Option<ProgressBar>> = Mutex::new(None);
@@ -41,7 +44,9 @@ pub fn set_progress_bar_width(width: usize) {
 
 pub fn print_progress_bar_info(info_name: &str, text: &str, info_color: Color, info_style: Style) {
     match *CURRENT_PROGRESS_BAR.lock().unwrap() {
-        Some(ref mut progress_bar) => progress_bar.print_info(info_name, text, info_color, info_style),
+        Some(ref mut progress_bar) => {
+            progress_bar.print_info(info_name, text, info_color, info_style)
+        }
         None => eprintln!("ERROR: Unable to print progress bar info (no progress bar)"),
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -46,9 +46,16 @@ pub fn print_progress_bar_info(info_name: &str, text: &str, info_color: Color, i
     }
 }
 
-pub fn set_progress_bar_action(action: &str, color: Color, style: Style, mode: Mode) {
+pub fn set_progress_bar_action(action: &str, color: Color, style: Style) {
     match *CURRENT_PROGRESS_BAR.lock().unwrap() {
-        Some(ref mut progress_bar) => progress_bar.set_action(action, color, style, mode),
+        Some(ref mut progress_bar) => progress_bar.set_action(action, color, style),
+        None => eprintln!("ERROR: Unable to set progress bar action (no progress bar)"),
+    }
+}
+
+pub fn set_progress_bar_action_with_mode(action: &str, color: Color, style: Style, mode: Mode) {
+    match *CURRENT_PROGRESS_BAR.lock().unwrap() {
+        Some(ref mut progress_bar) => progress_bar.set_action_with_mode(action, color, style, mode),
         None => eprintln!("ERROR: Unable to set progress bar action (no progress bar)"),
     }
 }

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -9,6 +9,7 @@ pub struct ProgressBar {
     action: String,
     action_color: Color,
     action_style: Style,
+    action_mode: Mode,
 }
 
 impl ProgressBar {
@@ -20,12 +21,12 @@ impl ProgressBar {
     /// 
     /// ```
     /// use progress_bar::progress_bar::ProgressBar;
-    /// use progress_bar::color::{Color, Style};
+    /// use progress_bar::color::{Color, Style, Mode};
     /// use std::{thread, time};
     /// 
     /// // if you have 81 pages to load
     /// let mut progress_bar = ProgressBar::new(81);
-    /// progress_bar.set_action("Loading", Color::Blue, Style::Bold);
+    /// progress_bar.set_action("Loading", Color::Blue, Style::Bold, Mode::Number);
     ///
     /// for i in 0..81 {
     ///     // load page
@@ -52,7 +53,8 @@ impl ProgressBar {
             width: 50,
             action: String::new(),
             action_color: Color::Black,
-            action_style: Style::Normal
+            action_style: Style::Normal,
+            action_mode: Mode::Number
         }
     }
 
@@ -89,10 +91,11 @@ impl ProgressBar {
     }
 
     /// Set the global action displayed before the progress bar.
-    pub fn set_action(&mut self, a: &str, c: Color, s: Style) {
+    pub fn set_action(&mut self, a: &str, c: Color, s: Style, m: Mode) {
         self.action = ProgressBar::set_good_size(a);
         self.action_color = c;
         self.action_style = s;
+        self.action_mode = m;
         self.display();
     }
 
@@ -126,7 +129,16 @@ impl ProgressBar {
                 print!(" ");
             }
         }
-        print!("] {}/{}", self.progression, self.max);
+        print!("] ");
+        match self.action_mode {
+            Mode::Number => {
+                print!("{}/{}", self.progression, self.max);
+            }
+            Mode::Percentage => {
+                print!("{:.2}%", (self.progression as f32 / self.max as f32) * 100.0);
+            }
+            _ => {}
+        }
         print!("\n\x1B[1A");
 
         #[allow(unused_must_use)]

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -91,7 +91,15 @@ impl ProgressBar {
     }
 
     /// Set the global action displayed before the progress bar.
-    pub fn set_action(&mut self, a: &str, c: Color, s: Style, m: Mode) {
+    pub fn set_action(&mut self, a: &str, c: Color, s: Style) {
+        self.action = ProgressBar::set_good_size(a);
+        self.action_color = c;
+        self.action_style = s;
+        self.action_mode = Mode::Number;
+        self.display();
+    }
+
+    pub fn set_action_with_mode(&mut self, a: &str, c: Color, s: Style, m: Mode) {
         self.action = ProgressBar::set_good_size(a);
         self.action_color = c;
         self.action_style = s;

--- a/src/style.rs
+++ b/src/style.rs
@@ -72,3 +72,9 @@ impl fmt::Display for Style {
         }
     }
 }
+
+pub enum Mode {
+    Number,
+    Percentage,
+    Nothing,
+}

--- a/tests/test-global.rs
+++ b/tests/test-global.rs
@@ -19,3 +19,22 @@ fn test() {
 
     finalize_progress_bar();
 }
+
+fn test_with_mode() {
+    init_progress_bar(100);
+    set_progress_bar_action_with_mode("Loading", Color::Blue, Style::Bold, Mode::Percentage);
+    
+    for i in 0..100 {
+        inc_progress_bar();
+        if i == 14 {
+            print_progress_bar_info("Error", "loading something", Color::Red, Style::Blink)
+        } else if i == 48 {
+            print_progress_bar_info("Found", "something", Color::Green, Style::Bold)
+        } else if i == 75 {
+            print_progress_bar_info("Warning", "potential error", Color::Yellow, Style::Normal)
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    finalize_progress_bar();
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 use progress_bar::pb::ProgressBar;
-use progress_bar::style::{Color, Style};
+use progress_bar::style::{Color, Style, Mode};
 use std::time;
 use std::thread;
 
@@ -25,6 +25,44 @@ fn test() {
 
     let mut test = ProgressBar::new(100);
     test.set_action("Loading", Color::Blue, Style::Bold);
+    
+    for i in 0..100 {
+        test.inc();
+        if i == 14 {
+            test.print_info("Failed", "to load a page", Color::Red, Style::Blink);
+        } else if i == 48 {
+            test.print_info("Found", "something interessant", Color::LightGreen, Style::Normal);
+        } else if i == 75 {
+            test.print_info("Warning", "empty page here", Color::Yellow, Style::Underlined);
+        }
+        thread::sleep(time::Duration::from_millis(50));
+    }
+    test.print_final_info("Loading", "Load complete", Color::LightGreen, Style::Bold);
+}
+
+
+#[test]
+fn test_with_mode() {
+    let mut test = ProgressBar::new(100);
+    test.set_action_with_mode("Loading", Color::Blue, Style::Bold, Mode::Percentage);
+    
+    for i in 0..100 {
+        test.inc();
+        if i == 14 {
+            test.print_info("Failed", "to load a page", Color::Red, Style::Blink);
+        } else if i == 48 {
+            test.print_info("Found", "something interessant", Color::LightGreen, Style::Normal);
+        } else if i == 75 {
+            test.print_info("Warning", "empty page here", Color::Yellow, Style::Underlined);
+        }
+        thread::sleep(time::Duration::from_millis(50));
+    }
+    test.finalize();
+
+    println!("Normal print macro");
+
+    let mut test = ProgressBar::new(100);
+    test.set_action_with_mode("Loading", Color::Blue, Style::Bold, Mode::Percentage);
     
     for i in 0..100 {
         test.inc();


### PR DESCRIPTION
This pull request add an extra option `action_mode`. This option is to specify what format used for displaying the bar.

`Mode::Number` is the default behavior, it prints `{progression}/{max}` (e.g. `1/123`) in the end of the bar.
`Mode::Percentage` prints the progress percentage with two decimals (e.g. `12.34%`) in the end of the bar.
`Mode::Nothing` not printing any additional info.